### PR TITLE
feat(myapi): add minimal service with GET /health and POST /echo

### DIFF
--- a/cmd/myapi/main.go
+++ b/cmd/myapi/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"ok"}`)
+	})
+
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		defer r.Body.Close()
+		var v any
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &v); err != nil {
+			v = map[string]string{"echo": string(body)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(v)
+	})
+
+	addr := ":8080"
+	log.Println("myapi listening on", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}


### PR DESCRIPTION
This PR adds a minimal HTTP service `myapi`:

- GET /health  -> {"status":"ok"}
- POST /echo   -> echos JSON body

How to run locally:
  go run ./cmd/myapi

Quick test:
  curl -s localhost:8080/health
  curl -s -X POST localhost:8080/echo \
       -H 'Content-Type: application/json' \
       -d '{"hola":"ux"}'

Branch name follows the policy: feature/myapi-service
Commit message follows Conventional Commits.
