### PR TITLE
feat: add lab6 API service with GET and POST

### DIFF
--- a/internal/sbi/api_lab6.go
+++ b/internal/sbi/api_lab6.go
@@ -1,0 +1,44 @@
+package sbi
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+)
+
+// Rutas del nuevo servicio /lab6
+func (s *Server) getLab6Route() []Route {
+    return []Route{
+        {
+            Name:   "Lab6 Info",
+            Method: http.MethodGet,
+            Pattern: "/", // -> /lab6/
+            APIFunc: func(c *gin.Context) {
+                c.JSON(http.StatusOK, gin.H{
+                    "message": "Lab 6 OK",
+                    "author":  "Paladinez",
+                })
+            },
+        },
+        {
+            Name:   "Lab6 Echo",
+            Method: http.MethodPost,
+            Pattern: "/echo", // -> /lab6/echo
+            APIFunc: func(c *gin.Context) {
+                var body map[string]interface{}
+
+                if err := c.BindJSON(&body); err != nil {
+                    c.JSON(http.StatusBadRequest, gin.H{
+                        "error": "invalid JSON body",
+                    })
+                    return
+                }
+
+                c.JSON(http.StatusOK, gin.H{
+                    "message":  "Lab 6 echo",
+                    "received": body,
+                })
+            },
+        },
+    }
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -37,15 +37,19 @@ func applyRoutes(group *gin.RouterGroup, routes []Route) {
 }
 
 func newRouter(s *Server) *gin.Engine {
-	router := logger_util.NewGinWithLogrus(logger.GinLog)
+    router := logger_util.NewGinWithLogrus(logger.GinLog)
 
-	defaultGroup := router.Group("/default")
-	applyRoutes(defaultGroup, s.getDefaultRoute())
+    defaultGroup := router.Group("/default")
+    applyRoutes(defaultGroup, s.getDefaultRoute())
 
-	spyFamilyGroup := router.Group("/spyfamily")
-	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
+    spyFamilyGroup := router.Group("/spyfamily")
+    applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
 
-	return router
+    // Nuevo servicio para el Lab 6
+    lab6Group := router.Group("/lab6")
+    applyRoutes(lab6Group, s.getLab6Route())
+
+    return router
 }
 
 func bindRouter(nf app.App, router *gin.Engine, tlsKeyLogPath string) (*http.Server, error) {


### PR DESCRIPTION
This pull request implements the Lab 6 task for Git & GitHub.

Changes:
- Added a new `/lab6` API group in the SBI router.
- Implemented `GET /lab6/` endpoint that returns a JSON object with a message and author name.
- Implemented `POST /lab6/echo` endpoint that reads a JSON request body and echoes it back in the response.

How to test:
1. Build the NF:
   ```bash
   make
