### PR TITLE
feat(api): add MyAPI service with GET and POST endpoints

### DIFF
--- a/internal/sbi/api_myapi.go
+++ b/internal/sbi/api_myapi.go
@@ -1,0 +1,42 @@
+package sbi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// getMyAPIRoute define las rutas de nuestro nuevo servicio "myapi".
+// Tendrá al menos un GET y un POST, como pide el lab.
+func (s *Server) getMyAPIRoute() []Route {
+	return []Route{
+		{
+			Name:    "MyAPI GET info",
+			Method:  http.MethodGet,
+			Pattern: "/",
+			APIFunc: func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{
+					"service": "myapi",
+					"status":  "ok",
+				})
+			},
+		},
+		{
+			Name:    "MyAPI POST echo",
+			Method:  http.MethodPost,
+			Pattern: "/echo",
+			APIFunc: func(c *gin.Context) {
+				var req struct {
+					Message string `json:"message" binding:"required"`
+				}
+				if err := c.ShouldBindJSON(&req); err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+					return
+				}
+				c.JSON(http.StatusOK, gin.H{
+					"echo": req.Message,
+				})
+			},
+		},
+	}
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -45,6 +45,9 @@ func newRouter(s *Server) *gin.Engine {
 	spyFamilyGroup := router.Group("/spyfamily")
 	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
 
+	myapiGroup := router.Group("/myapi")
+	applyRoutes(myapiGroup, s.getMyAPIRoute())
+
 	return router
 }
 


### PR DESCRIPTION
Este PR agrega un nuevo servicio HTTP llamado MyAPI al NF de ejemplo.

Se crea el archivo` internal/sbi/api_myapi.go `con dos endpoints:

`GET /myapi/`: retorna un JSON con el estado del servicio (service, status).

`POST /myapi/echo`: recibe un message en el cuerpo (JSON) y lo devuelve en la respuesta.

Se actualiza `internal/sbi/router.go` para registrar el nuevo grupo de rutas` /myapi`.

Probado ejecutando:

```
curl http://127.0.0.163:8000/myapi/

curl -X POST http://127.0.0.163:8000/myapi/echo -H "Content-Type: application/json" -d '{"message":"Hola desde MyAPI"}'
```