### PR TITLE
ci: add GitHub Actions workflow for build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI (nf-example)
+
+on:
+  push:
+    branches:
+      - main
+      - feature/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod tidy
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Build binary
+        run: go build -v ./cmd/main.go


### PR DESCRIPTION
Este PR agrega un workflow de GitHub Actions para automatizar parte del proceso de CI.

El workflow se ejecuta en `push` (main, feature/**) y en `pull_request` hacia `main`.

Usa `actions/setup-go` para configurar Go 1.22.

Ejecuta `go mod tidy`, `go test ./...` y `go build ./cmd/main.go` para validar que el proyecto compila correctamente.
Esto sigue la idea del Lab 7: tener un pipeline reproducible y automatizado para integrar cambios en el repositorio.